### PR TITLE
chore: prepare release 2.0.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,14 @@
 # History
 
+## 2.0.0 (2026-07-25)
+
+- Replace `lark-parser` with modern `lark`.
+- Require Python 3.11 or later.
+- Migrate project and dependency management from Poetry to uv.
+- Replace Tox, Black, isort, and Flake8 with direct uv commands and Ruff.
+- Modernize GitHub Actions and Codecov integration.
+- Update the documentation and development workflow.
+
 ## 1.0.2 (2022-02-25)
 * Introduce `PPLTLWeakBefore` and `PPLTLPastRelease` support
 * Hotfix problem on translation of the Once operator

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ltlf2dfa"
-version = "1.0.2"
+version = "2.0.0"
 description = "From LTLf/PPLTL to Deterministic Finite-state Automata (DFA)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -426,7 +426,7 @@ wheels = [
 
 [[package]]
 name = "ltlf2dfa"
-version = "1.0.2"
+version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Release 2.0.0

- Replace `lark-parser` with modern `lark`.
- Require Python 3.11 or later.
- Migrate project and dependency management from Poetry to uv.
- Replace Tox, Black, isort, and Flake8 with direct uv commands and Ruff.
- Modernize GitHub Actions and Codecov integration.
- Update the documentation and development workflow.